### PR TITLE
feat: Tweak display of entities (issue #39)

### DIFF
--- a/src/application/OutbreakTracker2.Application/Views/Dashboard/ClientOverview/InGameEnemy/InGameEnemyViewModel.cs
+++ b/src/application/OutbreakTracker2.Application/Views/Dashboard/ClientOverview/InGameEnemy/InGameEnemyViewModel.cs
@@ -95,7 +95,8 @@ public sealed partial class InGameEnemyViewModel : ObservableObject
             enemy.SlotId,
             enemy.NameId,
             enemy.CurHp,
-            enemy.MaxHp
+            enemy.MaxHp,
+            enemy.Name
         );
         IsDead = EnemyStatusUtility.IsDeadStatus(HealthStatus);
         IsInvincible = HealthStatus is "Invincible";

--- a/src/insights/OutbreakTracker2.UnitTests/EnemyStatusUtilityTests.cs
+++ b/src/insights/OutbreakTracker2.UnitTests/EnemyStatusUtilityTests.cs
@@ -149,4 +149,46 @@ public sealed class EnemyStatusUtilityTests
         await Assert.That(status).IsEqualTo("Dead");
         await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
     }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsExploded_ForMineEnumAtZeroHp()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: (byte)EnemyType.Mine,
+            curHp: 0,
+            maxHp: 1500
+        );
+
+        await Assert.That(status).IsEqualTo("Exploded");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsExploded_ForGasolineTankEnumAtZeroHp()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: (byte)EnemyType.GasolineTank,
+            curHp: 0,
+            maxHp: 1500
+        );
+
+        await Assert.That(status).IsEqualTo("Exploded");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsDestroyed_ForMineEnumAtMaxHpOneAndCurHpFfff()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: (byte)EnemyType.Mine,
+            curHp: 0xffff,
+            maxHp: 1
+        );
+
+        await Assert.That(status).IsEqualTo("Destroyed");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
 }

--- a/src/insights/OutbreakTracker2.UnitTests/EnemyStatusUtilityTests.cs
+++ b/src/insights/OutbreakTracker2.UnitTests/EnemyStatusUtilityTests.cs
@@ -45,4 +45,108 @@ public sealed class EnemyStatusUtilityTests
         await Assert.That(status).IsEqualTo("Empty");
         await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsFalse();
     }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsInvincible_ForFireWithMaxHpOne()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: (byte)EnemyType.Fire,
+            curHp: 0,
+            maxHp: 1
+        );
+
+        await Assert.That(status).IsEqualTo("Invincible");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsFalse();
+    }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsExploded_ForEntityWithMineNameAtZeroHp()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: 49,
+            curHp: 0,
+            maxHp: 1500,
+            entityName: "Test Mine"
+        );
+
+        await Assert.That(status).IsEqualTo("Exploded");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsExploded_ForEntityWithExplosiveNameAtZeroHp()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: 49,
+            curHp: 0,
+            maxHp: 1500,
+            entityName: "Explosive Device"
+        );
+
+        await Assert.That(status).IsEqualTo("Exploded");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsExploded_ForEntityWithFuelNameAtZeroHp()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: 49,
+            curHp: 0,
+            maxHp: 1500,
+            entityName: "Fuel Tank"
+        );
+
+        await Assert.That(status).IsEqualTo("Exploded");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsExploded_ForEntityWithCanisterNameAtZeroHp()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: 49,
+            curHp: 0,
+            maxHp: 1500,
+            entityName: "Canister 01"
+        );
+
+        await Assert.That(status).IsEqualTo("Exploded");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsExploded_ForEntityWithLowercaseMineNameAtZeroHp()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: 49,
+            curHp: 0,
+            maxHp: 1500,
+            entityName: "MINE_SPAWN"
+        );
+
+        await Assert.That(status).IsEqualTo("Exploded");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetHealthStatusForFileTwo_ReturnsDead_ForNonExplosiveEntityAtZeroHp()
+    {
+        string status = EnemyStatusUtility.GetHealthStatusForFileTwo(
+            slotId: 5,
+            nameId: 49,
+            curHp: 0,
+            maxHp: 1500,
+            entityName: "Standard Enemy"
+        );
+
+        await Assert.That(status).IsEqualTo("Dead");
+        await Assert.That(EnemyStatusUtility.IsDeadStatus(status)).IsTrue();
+    }
 }

--- a/src/libs/OutbreakTracker2.Outbreak/Utility/EnemyStatusUtility.cs
+++ b/src/libs/OutbreakTracker2.Outbreak/Utility/EnemyStatusUtility.cs
@@ -27,14 +27,9 @@ public static class EnemyStatusUtility
 
         return curHp switch
         {
-            0x0
-            or 0xffff
-            or >= 0x8000
-                when enemyType is not (EnemyType.Mine or EnemyType.GasolineTank) && !IsExplosiveEntity(entityName) =>
-                "Dead",
+            0x0 or 0xffff or >= 0x8000 when !IsExplosiveEntity(enemyType, entityName) => "Dead",
             0xffff when maxHp is 0x1 && enemyType is EnemyType.Mine => "Destroyed",
-            0x0 when enemyType is EnemyType.GasolineTank => "Exploded",
-            0x0 when IsExplosiveEntity(entityName) => "Exploded",
+            0x0 when IsExplosiveEntity(enemyType, entityName) => "Exploded",
             _ => $"{curHp}",
         };
     }
@@ -61,14 +56,9 @@ public static class EnemyStatusUtility
 
         return curHp switch
         {
-            0x0
-            or 0xffff
-            or >= 0x8000
-                when enemyType is not (EnemyType.Mine or EnemyType.GasolineTank) && !IsExplosiveEntity(entityName) =>
-                "Dead",
+            0x0 or 0xffff or >= 0x8000 when !IsExplosiveEntity(enemyType, entityName) => "Dead",
             0xffff when maxHp is 0x1 && enemyType is EnemyType.Mine => "Destroyed",
-            0x0 when enemyType is EnemyType.GasolineTank => "Exploded",
-            0x0 when IsExplosiveEntity(entityName) => "Exploded",
+            0x0 when IsExplosiveEntity(enemyType, entityName) => "Exploded",
             _ => $"{curHp}",
         };
     }
@@ -92,11 +82,20 @@ public static class EnemyStatusUtility
                 or EnemyType.Tentacles
                 or EnemyType.LeechTentacles;
 
+    private static bool IsExplosiveEntity(EnemyType enemyType, string entityName)
+    {
+        if (enemyType is EnemyType.Mine or EnemyType.GasolineTank)
+            return true;
+
+        return IsExplosiveEntity(entityName);
+    }
+
     private static bool IsExplosiveEntity(string entityName) =>
-        string.IsNullOrEmpty(entityName)
-            ? false
-            : entityName.Contains("canister", StringComparison.OrdinalIgnoreCase)
-                || entityName.Contains("mine", StringComparison.OrdinalIgnoreCase)
-                || entityName.Contains("explosive", StringComparison.OrdinalIgnoreCase)
-                || entityName.Contains("fuel", StringComparison.OrdinalIgnoreCase);
+        !string.IsNullOrEmpty(entityName)
+        && (
+            entityName.Contains("canister", StringComparison.OrdinalIgnoreCase)
+            || entityName.Contains("mine", StringComparison.OrdinalIgnoreCase)
+            || entityName.Contains("explosive", StringComparison.OrdinalIgnoreCase)
+            || entityName.Contains("fuel", StringComparison.OrdinalIgnoreCase)
+        );
 }

--- a/src/libs/OutbreakTracker2.Outbreak/Utility/EnemyStatusUtility.cs
+++ b/src/libs/OutbreakTracker2.Outbreak/Utility/EnemyStatusUtility.cs
@@ -5,7 +5,16 @@ namespace OutbreakTracker2.Outbreak.Utility;
 
 public static class EnemyStatusUtility
 {
-    public static string GetHealthStatusForFileOne(int slotId, byte nameId, ushort curHp, ushort maxHp)
+    public static string GetHealthStatusForFileOne(int slotId, byte nameId, ushort curHp, ushort maxHp) =>
+        GetHealthStatusForFileOne(slotId, nameId, curHp, maxHp, string.Empty);
+
+    public static string GetHealthStatusForFileOne(
+        int slotId,
+        byte nameId,
+        ushort curHp,
+        ushort maxHp,
+        string entityName
+    )
     {
         if (slotId is < 0 or >= GameConstants.MaxEnemies1)
             return $"Invalid enemy SlotId({slotId})";
@@ -13,19 +22,33 @@ public static class EnemyStatusUtility
         if (!EnumUtility.TryParseByValueOrMember(nameId, out EnemyType enemyType))
             return $"Failed to parse enemyType for nameId {nameId}";
 
-        if (IsInvincibleHealth(enemyType, curHp, maxHp))
+        if (IsInvincibleHealth(enemyType, curHp, maxHp, entityName))
             return "Invincible";
 
         return curHp switch
         {
-            0x0 or 0xffff or >= 0x8000 when enemyType is not (EnemyType.Mine or EnemyType.GasolineTank) => "Dead",
+            0x0
+            or 0xffff
+            or >= 0x8000
+                when enemyType is not (EnemyType.Mine or EnemyType.GasolineTank) && !IsExplosiveEntity(entityName) =>
+                "Dead",
             0xffff when maxHp is 0x1 && enemyType is EnemyType.Mine => "Destroyed",
             0x0 when enemyType is EnemyType.GasolineTank => "Exploded",
+            0x0 when IsExplosiveEntity(entityName) => "Exploded",
             _ => $"{curHp}",
         };
     }
 
-    public static string GetHealthStatusForFileTwo(int slotId, byte nameId, ushort curHp, ushort maxHp)
+    public static string GetHealthStatusForFileTwo(int slotId, byte nameId, ushort curHp, ushort maxHp) =>
+        GetHealthStatusForFileTwo(slotId, nameId, curHp, maxHp, string.Empty);
+
+    public static string GetHealthStatusForFileTwo(
+        int slotId,
+        byte nameId,
+        ushort curHp,
+        ushort maxHp,
+        string entityName
+    )
     {
         if (IsEmptyFileTwoSlot(slotId, maxHp))
             return "Empty";
@@ -33,14 +56,19 @@ public static class EnemyStatusUtility
         if (!EnumUtility.TryParseByValueOrMember(nameId, out EnemyType enemyType))
             return $"Failed to parse enemyType for nameId {nameId}";
 
-        if (IsInvincibleHealth(enemyType, curHp, maxHp))
+        if (IsInvincibleHealth(enemyType, curHp, maxHp, entityName))
             return "Invincible";
 
         return curHp switch
         {
-            0x0 or 0xffff or >= 0x8000 when enemyType is not (EnemyType.Mine or EnemyType.GasolineTank) => "Dead",
+            0x0
+            or 0xffff
+            or >= 0x8000
+                when enemyType is not (EnemyType.Mine or EnemyType.GasolineTank) && !IsExplosiveEntity(entityName) =>
+                "Dead",
             0xffff when maxHp is 0x1 && enemyType is EnemyType.Mine => "Destroyed",
             0x0 when enemyType is EnemyType.GasolineTank => "Exploded",
+            0x0 when IsExplosiveEntity(entityName) => "Exploded",
             _ => $"{curHp}",
         };
     }
@@ -50,7 +78,11 @@ public static class EnemyStatusUtility
     private static bool IsEmptyFileTwoSlot(int slotId, ushort maxHp) => slotId <= 0 || maxHp == 0;
 
     private static bool IsInvincibleHealth(EnemyType enemyType, ushort curHp, ushort maxHp) =>
+        IsInvincibleHealth(enemyType, curHp, maxHp, string.Empty);
+
+    private static bool IsInvincibleHealth(EnemyType enemyType, ushort curHp, ushort maxHp, string entityName) =>
         curHp == 0x7fff
+        || (enemyType is EnemyType.Fire && maxHp == 1)
         || (enemyType is EnemyType.Megabytes && maxHp == 1)
         || enemyType
             is EnemyType.Drainer11
@@ -59,4 +91,12 @@ public static class EnemyStatusUtility
                 or EnemyType.Neptune
                 or EnemyType.Tentacles
                 or EnemyType.LeechTentacles;
+
+    private static bool IsExplosiveEntity(string entityName) =>
+        string.IsNullOrEmpty(entityName)
+            ? false
+            : entityName.Contains("canister", StringComparison.OrdinalIgnoreCase)
+                || entityName.Contains("mine", StringComparison.OrdinalIgnoreCase)
+                || entityName.Contains("explosive", StringComparison.OrdinalIgnoreCase)
+                || entityName.Contains("fuel", StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
## Summary
Resolves #39: Tweak display of entities

## Changes
1. **Fire entity with maxHP=1**: Now treated as indestructible
   - Added check in `IsInvincibleHealth()` to detect Fire entities with maxHP=1
   - These entities will show "Invincible" status instead of "Dead"

2. **Explosive entities**: Now show "Exploded" status instead of "Dead" when reaching 0 HP
   - Added name-based detection for entities containing: "canister", "mine", "explosive", or "fuel"
   - These entities will display explosion icon instead of death icon
   - Works case-insensitively

## Implementation Details
- Added overloaded `GetHealthStatusForFileOne()` and `GetHealthStatusForFileTwo()` methods to accept entity name
- Maintained backward compatibility with existing method signatures (default to empty string)
- Added `IsExplosiveEntity()` helper method for name matching
- Added 7 new comprehensive unit tests covering all scenarios

## Testing
- Verified Fire with maxHP=1 is treated as Invincible
- Tested all explosive keywords ("mine", "explosive", "fuel", "canister") with case-insensitive matching
- Verified non-explosive entities still return "Dead" status
- All existing tests continue to pass

## Related Issue
Closes #39

<details>
<summary>Loom autonomy metadata</summary>

This GitHub action was executed by Loom on behalf of the authenticated user.

- Orchestrator: Loom
- InferenceProvider: GitHubCopilot
- Role: Developer
- Agent: FeatureDev
- Model: claude-haiku-4.5
- AutonomyPolicy: HybridWithEscalation

</details>